### PR TITLE
Improve handling of Crawl4AI responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ AI Researcher performs the following:
 - **Content Filtering & Output:**
   - `CLEANUP_REGEX`: Default regex provided for markdown cleaning.
   - `INCLUDE_IMAGES`: Default: `False`
-  - `MAX_CONTENT_LENGTH`: Default: `0` (No limit)
+  - `MAX_CONTENT_LENGTH`: Default: `20000`
   - `CITATION_STYLE`: Options: `inline`, `footnote`, `endnotes` (Default: `inline`)
 
 ---

--- a/crawl4ai_web_scrape.py
+++ b/crawl4ai_web_scrape.py
@@ -142,7 +142,17 @@ class Crawler:
                     response_json = await response.json()
                     task_id = response_json.get("task_id")
                     if not task_id:
-                        raise Exception(f"task_id missing in response: {response_json}")
+                        # Some Crawl4AI deployments return results directly
+                        if "result" in response_json or "results" in response_json:
+                            if hook:
+                                await hook(
+                                    Event.FINISHED,
+                                    {"task_id": None, "status": "completed"},
+                                )
+                            return response_json
+                        raise Exception(
+                            f"task_id missing in response: {response_json}"
+                        )
 
                 start_time = time.time()
 
@@ -364,7 +374,7 @@ class Tools:
             advanced=False,
         )
         MAX_CONTENT_LENGTH: int = Field(
-            default=0,
+            default=20000,
             description="Max length of output markdown (0 for no limit)",
             advanced=True,
         )


### PR DESCRIPTION
## Summary
- accept crawl results returned directly without a `task_id`
- set a default `MAX_CONTENT_LENGTH` of `20000`
- update README to match new default

## Testing
- `python -m py_compile crawl4ai_web_scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_686789f3bcec832e99e2d06b675f3442